### PR TITLE
Automatically find git hooks directory

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,8 @@
 [![Build Status](https://travis-ci.org/randomcoder/sbt-git-hooks.svg?branch=master)](https://travis-ci.org/randomcoder/sbt-git-hooks)
 
 SBT auto plugin to manage git hooks from within the project. This plugin will copy any files from the
-`git-hooks` directory into `.git/hooks` and ensure they are executable.
+`git-hooks` directory into `$(git rev-parse --git-path hooks)` (or different configured directories) and
+ensure they are executable.
 
 See the git hooks [documentation](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for details on
 the hooks that are available.
@@ -15,10 +16,10 @@ the hooks that are available.
 Add the plugin to your build with the following in `project/plugins.sbt`:
 
 ```
-addSbtPlugin("uk.co.randomcoding" % "sbt-git-hooks" % "0.2.0")
+addSbtPlugin("uk.co.randomcoding" % "sbt-git-hooks" % "0.3.0")
 ```
 
-Then run the task `writeHooks` to copy the hooks into `.git/hooks`
+Then run the task `writeHooks` to copy the hooks into `$(git rev-parse --git-path hooks)`.
 
 ### Licence
 

--- a/src/main/scala/uk/co/randomcoding/sbt/GitHooks.scala
+++ b/src/main/scala/uk/co/randomcoding/sbt/GitHooks.scala
@@ -18,11 +18,11 @@ package uk.co.randomcoding.sbt
 
 import java.nio.file.attribute.PosixFilePermissions
 import java.nio.file.{Files, StandardCopyOption}
-
 import sbt.Keys._
 import sbt._
 import sbt.internal.util.ManagedLogger
 
+import scala.sys.process.Process
 import scala.util.Properties
 
 object GitHooks extends AutoPlugin {
@@ -39,7 +39,7 @@ object GitHooks extends AutoPlugin {
 
   lazy val writeHooksTask = Def.task  {
     val hooksSource = hooksSourceDir.value.getOrElse(file("git-hooks"))
-    val targetDirectory = gitHooksDir.value.getOrElse(file(".git/hooks"))
+    val targetDirectory = gitHooksDir.value.getOrElse(file(Process("git rev-parse --git-path hooks").!!))
 
     WriteGitHooks(hooksSource, targetDirectory, streams.value.log)
   }


### PR DESCRIPTION
I am aware the repo is old but it is the first result for `sbt git hooks` in google so I think this improvement is worth merging.

Automatic hooks directory inference with `git` instead of hardcoded string allows to support worktrees and (some) setups with custom directories out-of-the-box.

Solves #2 .